### PR TITLE
Topic fix deep copy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,14 +48,14 @@ repos:
 
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0  # this is optional, use `pre-commit autoupdate` to get the latest rev!
+    rev: v5.0.0  # this is optional, use `pre-commit autoupdate` to get the latest rev!
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 
 -   repo: https://github.com/python-poetry/poetry
-    rev: '2.0.1'  # add version here
+    rev: '2.1.1'  # add version here
     hooks:
     -   id: poetry-check
     -   id: poetry-lock

--- a/src/openpmd_scipp/mesh_loader.py
+++ b/src/openpmd_scipp/mesh_loader.py
@@ -130,7 +130,7 @@ class DataRelay(sc.DataArray):
         self.series.flush()
         data *= self.record_component.unit_SI
         data = np.squeeze(data)
-        data_array = self.copy()
+        data_array = self.copy(deep=False)
         data_array.values = data
         return data_array
 


### PR DESCRIPTION
Default `deep=True` would create the full array, breaking the relay functionality and drastically increasing memory usage.